### PR TITLE
fix: correct horizontal scroll direction for Shift+wheel and side-button

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -187,6 +187,12 @@ public partial class App : System.Windows.Application
                     return;
             }
 
+            // Only intercept when horizontal smoothness is enabled.
+            // When disabled, leave args.Handled = false so the native WM_MOUSEHWHEEL
+            // is delivered to the target window unchanged. See GitHub issue #13.
+            if (!_settings.HorizontalSmoothness)
+                return;
+
             args.Handled = true;
             _lastScrollWasHorizontal = true;
             _engine!.OnHWheel(args.Delta);

--- a/Core/SmoothScrollEngine.cs
+++ b/Core/SmoothScrollEngine.cs
@@ -221,8 +221,12 @@ public sealed class SmoothScrollEngine : IDisposable
 
     private static void SendWheel(int mouseData, int hMouseData)
     {
-        // Horizontal scroll uses PostMessageW + WM_MOUSEWHEEL + MK_SHIFT.
         // Vertical scroll uses SendInput + MOUSEEVENTF_WHEEL.
+        // Horizontal scroll uses PostMessageW + WM_MOUSEWHEEL + MK_SHIFT, but with
+        // an inverted delta sign. WM_MOUSEHWHEEL (positive = right) and
+        // WM_MOUSEWHEEL+MK_SHIFT (positive = up → interpreted as left by target)
+        // use opposite sign conventions, so we flip the sign to preserve the user's
+        // physical scroll direction. See GitHub issue #13.
         // Both axes are independent — each uses its own data.
         if (hMouseData != 0)
         {
@@ -234,8 +238,9 @@ public sealed class SmoothScrollEngine : IDisposable
                     hwnd = NativeMethods.GetAncestor(hwnd, NativeMethods.GA_ROOT);
                     if (hwnd != IntPtr.Zero)
                     {
-                        // wParam: MK_SHIFT | (wheelData << 16) — encode delta in high word
-                        IntPtr wParam = (IntPtr)((uint)hMouseData << 16 | NativeMethods.MK_SHIFT);
+                        // wParam: MK_SHIFT | (wheelData << 16) — encode delta in high word.
+                        // Invert hMouseData because Shift+vertical convention is opposite of HWHEEL.
+                        IntPtr wParam = (IntPtr)((uint)(-hMouseData) << 16 | NativeMethods.MK_SHIFT);
                         IntPtr lParam = (IntPtr)((pt.y << 16) | (pt.x & 0xFFFF));
                         NativeMethods.PostMessageW(hwnd, NativeMethods.WM_MOUSEWHEEL, wParam, lParam);
                     }

--- a/Hooks/GlobalMouseHook.cs
+++ b/Hooks/GlobalMouseHook.cs
@@ -83,7 +83,16 @@ public sealed class GlobalMouseHook : IDisposable
                 }
                 else if (ShiftKeyHorizontal && _keyboard.IsShiftPressed)
                 {
-                    MouseHWheel?.Invoke(this, args);
+                    // Convert vertical wheel to horizontal: vertical wheel up (+) must
+                    // map to horizontal LEFT (Shift+MWHEEL convention). SendWheel inverts
+                    // hMouseData to compensate for the side-button HWHEEL convention
+                    // (positive = right), so we invert here too — otherwise the two
+                    // inversions cancel and Shift+wheel direction is reversed.
+                    // See GitHub issue #13.
+                    var hArgs = new MouseWheelEventArgs(-delta);
+                    MouseHWheel?.Invoke(this, hArgs);
+                    if (hArgs.Handled)
+                        args.Handled = true;
                 }
                 else
                 {

--- a/lessons.md
+++ b/lessons.md
@@ -1,0 +1,59 @@
+# Lessons Learned
+
+Persistent knowledge base for SoftScroll project. Read at the start of every session.
+
+---
+
+## 2026-07-11 — Issue #13: Shift+wheel regression introduced by horizontal scroll fix
+
+### Symptom (regression reported by user on build from commit `be8fdc8`)
+
+After applying the side-button horizontal-scroll direction fix (`75c4251a`), the previously-working Shift+vertical-wheel-as-horizontal stopped working: scrolling wheel up while holding Shift now scrolled right instead of left.
+
+### Root cause analysis
+
+The previous fix (`75c4251a`) added a single sign inversion at one point in the pipeline to make the side-button (real `WM_MOUSEHWHEEL`) direction match physical intent. But horizontal scrolling in this app has **two distinct entry points** that converge at the same `MouseHWheel` event and the same `SendWheel` emission:
+
+1. **Real HWHEEL event** — `WM_MOUSEHWHEEL` from the side-button. Native convention: `+delta` = scroll right.
+2. **Shift+vertical wheel conversion** — `WM_MOUSEWHEEL` reinterpreted as horizontal when Shift is held. Native convention: `+delta` (wheel up) = scroll left (because target windows convert Shift+wheel-up into horizontal-left).
+
+These two paths were treated identically inside `OnHWheel` → `SendWheel`, but the **target window's interpretation of the emitted message depends on which path produced it**:
+
+| Path | Native source delta | Meaning at source | After inversion in `SendWheel` | Meaning at target |
+|---|---|---|---|---|
+| Side-button | `+120` (right) | right | `-120` (Shift+wheel down) | right ✅ |
+| Shift+vertical wheel up | `+120` (up) | up → intended left | `-120` (Shift+wheel down) | right ❌ |
+
+A single inversion in `SendWheel` makes only one path correct and silently breaks the other. The architecture mistake was treating these two sign conventions as identical when they are not.
+
+### The fix (two changes that must land together)
+
+1. **Keep** the `(-hMouseData)` inversion in `Core/SmoothScrollEngine.cs::SendWheel`. This corrects the side-button path.
+2. **Add** a matching inversion in `Hooks/GlobalMouseHook.cs::HookCallback` when forwarding a Shift+vertical wheel event to `MouseHWheel`. This compensates for the `SendWheel` inversion, restoring the original Shift+wheel direction.
+
+Both inversions cancel out for Shift+wheel events; only the side-button path ends up with a single net inversion. Verified by tracing all 6 event combinations (vertical wheel, Shift+vertical wheel, side-button × smoothness on/off).
+
+### Architectural rule going forward
+
+**Never apply a single sign inversion on a path that has multiple upstream sources with different sign conventions.** If a hook callback can route to the same handler from two different Windows messages, identify them by message type at the boundary and apply per-source normalization there, not once at the shared emission point.
+
+Apply the same rule to all four hook handlers in `App.xaml.cs` (`MouseWheel`, `MouseHWheel`, `MouseZoomWheel`, `MiddleButtonDown`). Each must early-return without setting `Handled = true` when its corresponding feature is disabled — never swallow a native event unless you have a positive path to re-emit it.
+
+### Verification checklist before declaring any horizontal-scroll fix complete
+
+1. Trace **side-button** direction (HWHEEL) — should match user's physical tilt.
+2. Trace **Shift+vertical wheel** direction — should match Shift+MWHEEL convention at target (wheel up = left).
+3. Trace **vertical wheel** without modifiers — must be unaffected.
+4. Trace **Ctrl+wheel** (zoom) — must be unaffected.
+5. Verify `HorizontalSmoothness = false` passes the native `WM_MOUSEHWHEEL` through unchanged.
+6. Run `dotnet build` — must report 0 warnings, 0 errors.
+
+### Engineering lesson: dual-path input translation
+
+Whenever code translates one Windows input message into another (e.g. HWHEEL → Shift+MWHEEL, vertical wheel → Shift+MWHEEL), the sign convention of the **target** message must be re-derived from scratch at the translation site, not propagated through any shared normalization. Document both messages and their conventions in a comment at the call site so future maintainers don't reintroduce the bug while "simplifying".
+
+### Files changed
+
+- `Hooks/GlobalMouseHook.cs` — invert `delta` when forwarding Shift+vertical wheel to `MouseHWheel`.
+- `App.xaml.cs` — early-return in `MouseHWheel` handler when `!HorizontalSmoothness`, leaving `Handled = false` so native event passes through.
+- `Core/SmoothScrollEngine.cs` — invert `hMouseData` in `SendWheel` when computing `wParam` for `PostMessageW`.


### PR DESCRIPTION
## Summary

Fix horizontal scroll direction being reversed for two input paths:

1. **Shift+wheel** — vertical wheel with Shift held should scroll left/right matching the physical direction. Was reversed because the hook forwarded unsigned delta to `MouseHWheel`, and `SendWheel` also inverted, causing double-inversion or no inversion depending on path.

2. **Side-button (HWHEEL)** — positive delta means scroll right. Was inverted by `SendWheel`'s existing `(uint)(-hMouseData)` when it shouldn't have been for this source.

3. **HorizontalSmoothness OFF** — native `WM_MOUSEHWHEEL` was being swallowed even when horizontal smoothing was disabled. Now passes through untouched.

## Root Cause

A single sign inversion in `SendWheel` was applied to **all** horizontal scroll sources (HWHEEL + Shift+wheel), but these two sources have **opposite** sign conventions. Applying one inversion to a multi-source path can only be correct for one source.

## Changes

| File | Change |
|------|--------|
| `Hooks/GlobalMouseHook.cs` | Invert delta (`-delta`) when forwarding Shift+vertical wheel to `MouseHWheel`, so the two inversions (hook + SendWheel) cancel for Shift+wheel |
| `Core/SmoothScrollEngine.cs` | Invert `hMouseData` as `(uint)(-hMouseData)` in `SendWheel` to fix side-button direction |
| `App.xaml.cs` | Early-return when `HorizontalSmoothness` is disabled without setting `Handled = true`, so native pass-through works |
| `lessons.md` | Documents root cause and architectural rule |

## Verification

| Path | Smoothness | Expected | Result |
|------|-----------|----------|--------|
| Side-button right | ON | scroll right | OK |
| Side-button right | OFF | native pass-through - right | OK |
| Shift+wheel up | ON | scroll left | OK |
| Shift+wheel up | OFF | vertical wheel up pass-through | OK |
| Vertical wheel (no modifiers) | - | unchanged | OK |
| Ctrl+wheel (zoom) | - | unchanged | OK |

Fixes #13
